### PR TITLE
Fix for passlib install breaking pip in Ubuntu 16.04

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -85,7 +85,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # If python-pip install failed and setuptools exists, try that
     if [ -z "$(which pip)" ] && [ -z "$(which easy_install)" ]; then
-      yum -y install python-setuptools
+      apt_install python-setuptools
       easy_install pip
     elif [ -z "$(which pip)" ] && [ -n "$(which easy_install)" ]; then
       easy_install pip

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -133,7 +133,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     echo 'WARN: Not all functionality of ansible may be available'
   fi
 
-  pip install -q six --upgrade
+  pip install -q --upgrade six pyopenssl 
   mkdir -p /etc/ansible/
   printf "%s\n" "[local]" "localhost" > /etc/ansible/hosts
   if [ -z "$ANSIBLE_VERSION" ]; then

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -85,7 +85,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # If python-pip install failed and setuptools exists, try that
     if [ -z "$(which pip)" ] || [ -z "$(pip)" ] ; then
-      [ -n "$(which easy_install)" ] || apt_install python-setuptools
+      [ -z "$(which easy_install)" ] || apt_install python-setuptools
       echo "Upgrading pip module"
       easy_install --upgrade pip
       pip install -q --upgrade pyopenssl

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -84,11 +84,11 @@ if [ ! "$(which ansible-playbook)" ]; then
     dpkg_check_lock && apt-cache search ^git$ | grep -q "^git\s" && apt_install git || apt_install git-core
 
     # If python-pip install failed and setuptools exists, try that
-    if ( [ -z "$(which pip)" ] || [ -z "$(pip)" ] ) && [ -z "$(which easy_install)" ]; then
-      apt_install python-setuptools
+    if [ -z "$(which pip)" ] || [ -z "$(pip)" ] ; then
+      [ -n "$(which easy_install)" ] || apt_install python-setuptools
+      echo "Upgrading pip module"
       easy_install --upgrade pip
-    elif ( [ -z "$(which pip)" ] || [ -z "$(pip)" ] ) && [ -n "$(which easy_install)" ]; then
-      easy_install --upgrade pip
+      pip install -q --upgrade pyopenssl
     fi
     # If python-keyczar apt package does not exist, use pip
     [ -z "$( apt-cache search python-keyczar )" ] && sudo pip install python-keyczar
@@ -133,7 +133,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     echo 'WARN: Not all functionality of ansible may be available'
   fi
 
-  pip install -q --upgrade six pyopenssl 
+  pip install -q --upgrade six
   mkdir -p /etc/ansible/
   printf "%s\n" "[local]" "localhost" > /etc/ansible/hosts
   if [ -z "$ANSIBLE_VERSION" ]; then

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -84,10 +84,10 @@ if [ ! "$(which ansible-playbook)" ]; then
     dpkg_check_lock && apt-cache search ^git$ | grep -q "^git\s" && apt_install git || apt_install git-core
 
     # If python-pip install failed and setuptools exists, try that
-    if [ -z "$(which pip)" ] && [ -z "$(pip)" ] && [ -z "$(which easy_install)" ]; then
+    if ( [ -z "$(which pip)" ] || [ -z "$(pip)" ] ) && [ -z "$(which easy_install)" ]; then
       apt_install python-setuptools
       easy_install --upgrade pip
-    elif [ -z "$(which pip)" ] && [ -z "$(pip)" ] [ -n "$(which easy_install)" ]; then
+    elif ( [ -z "$(which pip)" ] || [ -z "$(pip)" ] ) && [ -n "$(which easy_install)" ]; then
       easy_install --upgrade pip
     fi
     # If python-keyczar apt package does not exist, use pip
@@ -107,7 +107,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     zypper --quiet --non-interactive install libffi-devel openssl-devel python-devel perl-Error
     zypper --quiet --non-interactive install git || zypper --quiet --non-interactive install git-core
 
-    # If python-pip install failed and setuptools exists, try that
+    # If python-pip install failed and tools exists, try that
     if [ -z "$(which pip)" ] && [ -z "$(which easy_install)" ]; then
       zypper --quiet --non-interactive install python-setuptools
       easy_install pip

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -96,7 +96,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # Install passlib for encrypt
     apt_install build-essential
-    apt_install python-all-dev python-mysqldb sshpass && pip install pyrax pysphere boto passlib dnspython
+    apt_install python-all-dev python-mysqldb sshpass && pip install pyrax pysphere boto passlib dnspython pyopenssl
 
     # Install Ansible module dependencies
     apt_install bzip2 file findutils git gzip mercurial procps subversion sudo tar debianutils unzip xz-utils zip python-selinux python-boto

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -84,11 +84,11 @@ if [ ! "$(which ansible-playbook)" ]; then
     dpkg_check_lock && apt-cache search ^git$ | grep -q "^git\s" && apt_install git || apt_install git-core
 
     # If python-pip install failed and setuptools exists, try that
-    if [ -z "$(which pip)" ] && [ -z "$(which easy_install)" ]; then
+    if [ -z "$(which pip)" ] && [ -z "$(pip)" ] && [ -z "$(which easy_install)" ]; then
       apt_install python-setuptools
-      easy_install pip
-    elif [ -z "$(which pip)" ] && [ -n "$(which easy_install)" ]; then
-      easy_install pip
+      easy_install --upgrade pip
+    elif [ -z "$(which pip)" ] && [ -z "$(pip)" ] [ -n "$(which easy_install)" ]; then
+      easy_install --upgrade pip
     fi
     # If python-keyczar apt package does not exist, use pip
     [ -z "$( apt-cache search python-keyczar )" ] && sudo pip install python-keyczar

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -88,7 +88,7 @@ if [ ! "$(which ansible-playbook)" ]; then
       [ -z "$(which easy_install)" ] || apt_install python-setuptools
       echo "Upgrading pip module"
       easy_install --upgrade pip
-      pip install -q --upgrade pyopenssl
+      pip install --upgrade pyopenssl
     fi
     # If python-keyczar apt package does not exist, use pip
     [ -z "$( apt-cache search python-keyczar )" ] && sudo pip install python-keyczar
@@ -133,13 +133,13 @@ if [ ! "$(which ansible-playbook)" ]; then
     echo 'WARN: Not all functionality of ansible may be available'
   fi
 
-  pip install -q --upgrade six
+  pip install --upgrade six
   mkdir -p /etc/ansible/
   printf "%s\n" "[local]" "localhost" > /etc/ansible/hosts
   if [ -z "$ANSIBLE_VERSION" ]; then
-    pip install -q ansible
+    pip install ansible
   else
-    pip install -q ansible=="$ANSIBLE_VERSION"
+    pip install ansible=="$ANSIBLE_VERSION"
   fi
   if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
     # Fix for pycrypto pip / yum issue

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-#TODO.md
+
+set -x
 
 if [ "$1" = "-v" ]; then
   ANSIBLE_VERSION="${2}"

--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-set -x
+#TODO.md
 
 if [ "$1" = "-v" ]; then
   ANSIBLE_VERSION="${2}"
@@ -85,11 +84,11 @@ if [ ! "$(which ansible-playbook)" ]; then
     dpkg_check_lock && apt-cache search ^git$ | grep -q "^git\s" && apt_install git || apt_install git-core
 
     # If python-pip install failed and setuptools exists, try that
-    if [ -z "$(which pip)" ] || [ -z "$(pip)" ] ; then
-      [ -z "$(which easy_install)" ] || apt_install python-setuptools
-      echo "Upgrading pip module"
-      easy_install --upgrade pip
-      pip install --upgrade pyopenssl
+    if [ -z "$(which pip)" ] && [ -z "$(which easy_install)" ]; then
+      yum -y install python-setuptools
+      easy_install pip
+    elif [ -z "$(which pip)" ] && [ -n "$(which easy_install)" ]; then
+      easy_install pip
     fi
     # If python-keyczar apt package does not exist, use pip
     [ -z "$( apt-cache search python-keyczar )" ] && sudo pip install python-keyczar
@@ -108,7 +107,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     zypper --quiet --non-interactive install libffi-devel openssl-devel python-devel perl-Error
     zypper --quiet --non-interactive install git || zypper --quiet --non-interactive install git-core
 
-    # If python-pip install failed and tools exists, try that
+    # If python-pip install failed and setuptools exists, try that
     if [ -z "$(which pip)" ] && [ -z "$(which easy_install)" ]; then
       zypper --quiet --non-interactive install python-setuptools
       easy_install pip
@@ -134,13 +133,13 @@ if [ ! "$(which ansible-playbook)" ]; then
     echo 'WARN: Not all functionality of ansible may be available'
   fi
 
-  pip install --upgrade six
+  pip install -q six --upgrade
   mkdir -p /etc/ansible/
   printf "%s\n" "[local]" "localhost" > /etc/ansible/hosts
   if [ -z "$ANSIBLE_VERSION" ]; then
-    pip install ansible
+    pip install -q ansible
   else
-    pip install ansible=="$ANSIBLE_VERSION"
+    pip install -q ansible=="$ANSIBLE_VERSION"
   fi
   if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
     # Fix for pycrypto pip / yum issue


### PR DESCRIPTION
python-pip on ubuntu 16.04 breaks with:

    AttributeError: 'module' object has no attribute 'SSL_ST_INIT'

Workaround: upgrade pip using easy_install